### PR TITLE
Clang format and clang tidy fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 .vscode/
 .DS_Store
+.github/

--- a/include/gps.hpp
+++ b/include/gps.hpp
@@ -2,53 +2,53 @@
 #define OBC_GPS_HPP
 
 #include <Adafruit_GPS.h>
-#include "error.hpp"
 
+#include "error.hpp"
 
 namespace obc {
 
-    constexpr bool GPSECHO = false;
+constexpr bool GPSECHO = false;
 
-    using Gps = Adafruit_GPS;
-    using Gps_float = nmea_float_t;
+using Gps = Adafruit_GPS;
+using Gps_float = nmea_float_t;
 
-    struct GpsTime
-    {
-        uint8_t hour;
-        uint8_t minute;
-        uint8_t seconds;
-        uint16_t milliseconds;
-    };
+struct GpsTime {
+    uint8_t hour;
+    uint8_t minute;
+    uint8_t seconds;
+    uint16_t milliseconds;
+};
 
-    struct GpsDate
-    {
-        uint8_t year;
-        uint8_t month;
-        uint8_t day;
-    };
-    
-    struct GpsPosition{
-        bool fix; 
-        uint8_t fixquality;
-        Gps_float longitude; char lon;
-        Gps_float latitude; char lat;
-        Gps_float altitude;
-        Gps_float speed;
-        uint8_t satelites;
-    };
+struct GpsDate {
+    uint8_t year;
+    uint8_t month;
+    uint8_t day;
+};
 
-    struct GpsMeasurments{
-        GpsTime time;
-        GpsDate date;
-        GpsPosition gpsposition;
-        Error err;
-    };
+struct GpsPosition {
+    bool fix;
+    uint8_t fixquality;
+    Gps_float longitude;
+    char lon;
+    Gps_float latitude;
+    char lat;
+    Gps_float altitude;
+    Gps_float speed;
+    uint8_t satelites;
+};
 
-    void init(Gps& gps);
-    GpsMeasurments measure_gps(Gps& gps);
-    void print(const GpsTime& gps_time);
-    void print(const GpsDate& gps_date);
-    void print(const GpsPosition& gps_position);
-}
+struct GpsMeasurments {
+    GpsTime time;
+    GpsDate date;
+    GpsPosition gpsposition;
+    Error err;
+};
+
+void init(Gps& gps);
+GpsMeasurments measure_gps(Gps& gps);
+void print(const GpsTime& gps_time);
+void print(const GpsDate& gps_date);
+void print(const GpsPosition& gps_position);
+}  // namespace obc
 
 #endif

--- a/include/gps.hpp
+++ b/include/gps.hpp
@@ -4,11 +4,10 @@
 #include <Adafruit_GPS.h>
 #include "error.hpp"
 
-#define GPSSerial Serial3
-#define GPSECHO false
-
 
 namespace obc {
+
+    constexpr bool GPSECHO = false;
 
     using Gps = Adafruit_GPS;
     using Gps_float = nmea_float_t;

--- a/include/gps.hpp
+++ b/include/gps.hpp
@@ -1,0 +1,55 @@
+#ifndef OBC_GPS_HPP
+#define OBC_GPS_HPP
+
+#include <Adafruit_GPS.h>
+#include "error.hpp"
+
+#define GPSSerial Serial3
+#define GPSECHO false
+
+
+namespace obc {
+
+    using Gps = Adafruit_GPS;
+    using Gps_float = nmea_float_t;
+
+    struct GpsTime
+    {
+        uint8_t hour;
+        uint8_t minute;
+        uint8_t seconds;
+        uint16_t milliseconds;
+    };
+
+    struct GpsDate
+    {
+        uint8_t year;
+        uint8_t month;
+        uint8_t day;
+    };
+    
+    struct GpsPosition{
+        bool fix; 
+        uint8_t fixquality;
+        Gps_float longitude; char lon;
+        Gps_float latitude; char lat;
+        Gps_float altitude;
+        Gps_float speed;
+        uint8_t satelites;
+    };
+
+    struct GpsMeasurments{
+        GpsTime time;
+        GpsDate date;
+        GpsPosition gpsposition;
+        Error err;
+    };
+
+    void init(Gps& gps);
+    GpsMeasurments measure_gps(Gps& gps);
+    void print(const GpsTime& gps_time);
+    void print(const GpsDate& gps_date);
+    void print(const GpsPosition& gps_position);
+}
+
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,5 +17,8 @@ build_flags = -std=gnu++17
 src_build_flags = -Wall -Wextra -Wpedantic -Wconversion -Werror
 extra_scripts = script/include_lib_dirs.py
 check_tool = clangtidy
+lib_deps = 
+	;mikalhart/TinyGPSPlus@^1.0.2
+	adafruit/Adafruit GPS Library@^1.5.4
 check_flags =
     clangtidy: --checks=-*,bugprone-*,cert-*,-cert-err58-cpp,cppcoreguidelines-*,-cppcoreguidelines-pro-bounds-pointer-arithmetic,modernize-*,-cppcoreguidelines-avoid-non-const-global-variables,-modernize-avoid-c-arrays,-modernize-use-nodiscard,-modernize-use-trailing-return-type,readability-*,-readability-braces-around-statements,performance-*,clang-analyzer-*,performance-*,hicpp-*,-hicpp-special-member-functions,-hicpp-avoid-c-arrays,-hicpp-use-nullptr,-hicpp-braces-around-statements,-hicpp-no-array

--- a/src/gps.cpp
+++ b/src/gps.cpp
@@ -1,23 +1,25 @@
 #include "gps.hpp"
 #include <Arduino.h>
 
+
 namespace obc{
 
+    constexpr auto gps_baud_rate = 9600L;
+    constexpr auto gps_delay = 1000L;
     void init(Gps& gps)
     {
-        Serial.begin(115200);
-        gps.begin(9600);
+        gps.begin(gps_baud_rate);
         gps.sendCommand(PMTK_SET_NMEA_OUTPUT_RMCGGA);
         gps.sendCommand(PMTK_SET_NMEA_UPDATE_1HZ); // 1 Hz update rate
         gps.sendCommand(PGCMD_ANTENNA);
-        delay(1000);
-        GPSSerial.println(PMTK_Q_RELEASE);
+        delay(gps_delay);
+        Serial3.println(PMTK_Q_RELEASE);
     }
     GpsMeasurments measure_gps(Gps& gps)
     {
         char c = gps.read();
             if (GPSECHO)
-              if (c) Serial.print(c);
+              if (gps.read() != 0) Serial.print(c);
           if (gps.newNMEAreceived()) {
             if (!gps.parse(gps.lastNMEA()))
             return {{},{},{},Error::Busy};

--- a/src/gps.cpp
+++ b/src/gps.cpp
@@ -1,72 +1,89 @@
 #include "gps.hpp"
+
 #include <Arduino.h>
 
+namespace obc {
 
-namespace obc{
-
-    constexpr auto gps_baud_rate = 9600L;
-    constexpr auto gps_delay = 1000L;
-    void init(Gps& gps)
-    {
-        gps.begin(gps_baud_rate);
-        gps.sendCommand(PMTK_SET_NMEA_OUTPUT_RMCGGA);
-        gps.sendCommand(PMTK_SET_NMEA_UPDATE_1HZ); // 1 Hz update rate
-        gps.sendCommand(PGCMD_ANTENNA);
-        delay(gps_delay);
-        Serial3.println(PMTK_Q_RELEASE);
-    }
-    GpsMeasurments measure_gps(Gps& gps)
-    {
-        char c = gps.read();
-            if (GPSECHO)
-              if (gps.read() != 0) Serial.print(c);
-          if (gps.newNMEAreceived()) {
-            if (!gps.parse(gps.lastNMEA()))
-            return {{},{},{},Error::Busy};
-          }
-        return {{gps.hour,gps.minute,gps.seconds,gps.milliseconds},
-                {gps.year,gps.month,gps.day},
-                {gps.fix,gps.fixquality,gps.longitudeDegrees,gps.lon,gps.latitudeDegrees,gps.lat,gps.altitude,gps.speed,gps.satellites},
-                Error::Ok};
-
-    }
-    void print(const GpsTime& gps_time)
-    {
-        Serial.print("\nTime: ");
-        if (gps_time.hour < 10) { Serial.print('0'); }
-        Serial.print(gps_time.hour, DEC); Serial.print(':');
-        if (gps_time.minute < 10) { Serial.print('0'); }
-        Serial.print(gps_time.minute, DEC); Serial.print(':');
-        if (gps_time.seconds < 10) { Serial.print('0'); }
-        Serial.print(gps_time.seconds, DEC); Serial.print('.');
-        if (gps_time.milliseconds < 10) {
-          Serial.print("00");
-        } else if (gps_time.milliseconds > 9 && gps_time.milliseconds < 100) {
-          Serial.print("0");
-        }
-        Serial.println(gps_time.milliseconds);
-    }
-    void print(const GpsDate& gps_date)
-    {
-        Serial.print("Date: ");
-        Serial.print(gps_date.day, DEC); Serial.print('/');
-        Serial.print(gps_date.month, DEC); Serial.print("/20");
-        Serial.println(gps_date.year, DEC);
-      
-    }
-    void print(const GpsPosition& gps_position)
-    {
-        Serial.print("Fix: "); Serial.print((int)gps_position.fix);
-        Serial.print(" quality: "); Serial.println((int)gps_position.fixquality);
-        if (gps_position.fix) {
-          Serial.print("Location: ");
-          Serial.print(gps_position.latitude, 4); Serial.print(gps_position.lat);
-          Serial.print(", ");
-          Serial.print(gps_position.longitude, 4); Serial.println(gps_position.lon);
-          Serial.print("Speed (km/h): "); Serial.println(gps_position.speed/1.85166);
-          Serial.print("Altitude: "); Serial.println(gps_position.altitude);
-          Serial.print("Satellites: "); Serial.println((int)gps_position.satelites);
-        }
-    }
-
+constexpr auto gps_baud_rate = 9600L;
+constexpr auto gps_delay = 1000L;
+void init(Gps& gps)
+{
+    gps.begin(gps_baud_rate);
+    gps.sendCommand(PMTK_SET_NMEA_OUTPUT_RMCGGA);
+    gps.sendCommand(PMTK_SET_NMEA_UPDATE_1HZ);  // 1 Hz update rate
+    gps.sendCommand(PGCMD_ANTENNA);
+    delay(gps_delay);
+    Serial3.println(PMTK_Q_RELEASE);
 }
+GpsMeasurments measure_gps(Gps& gps)
+{
+    char c = gps.read();
+    if (GPSECHO)
+        if (gps.read() != 0) Serial.print(c);
+    if (gps.newNMEAreceived()) {
+        if (!gps.parse(gps.lastNMEA())) return {{}, {}, {}, Error::Busy};
+    }
+    return {
+        {gps.hour, gps.minute, gps.seconds, gps.milliseconds},
+        {gps.year, gps.month, gps.day},
+        {gps.fix,
+         gps.fixquality,
+         gps.longitudeDegrees,
+         gps.lon,
+         gps.latitudeDegrees,
+         gps.lat,
+         gps.altitude,
+         gps.speed,
+         gps.satellites},
+        Error::Ok};
+}
+void print(const GpsTime& gps_time)
+{
+    Serial.print("\nTime: ");
+    if (gps_time.hour < 10) { Serial.print('0'); }
+    Serial.print(gps_time.hour, DEC);
+    Serial.print(':');
+    if (gps_time.minute < 10) { Serial.print('0'); }
+    Serial.print(gps_time.minute, DEC);
+    Serial.print(':');
+    if (gps_time.seconds < 10) { Serial.print('0'); }
+    Serial.print(gps_time.seconds, DEC);
+    Serial.print('.');
+    if (gps_time.milliseconds < 10) { Serial.print("00"); }
+    else if (gps_time.milliseconds > 9 && gps_time.milliseconds < 100) {
+        Serial.print("0");
+    }
+    Serial.println(gps_time.milliseconds);
+}
+void print(const GpsDate& gps_date)
+{
+    Serial.print("Date: ");
+    Serial.print(gps_date.day, DEC);
+    Serial.print('/');
+    Serial.print(gps_date.month, DEC);
+    Serial.print("/20");
+    Serial.println(gps_date.year, DEC);
+}
+void print(const GpsPosition& gps_position)
+{
+    Serial.print("Fix: ");
+    Serial.print((int)gps_position.fix);
+    Serial.print(" quality: ");
+    Serial.println((int)gps_position.fixquality);
+    if (gps_position.fix) {
+        Serial.print("Location: ");
+        Serial.print(gps_position.latitude, 4);
+        Serial.print(gps_position.lat);
+        Serial.print(", ");
+        Serial.print(gps_position.longitude, 4);
+        Serial.println(gps_position.lon);
+        Serial.print("Speed (km/h): ");
+        Serial.println(gps_position.speed / 1.85166);
+        Serial.print("Altitude: ");
+        Serial.println(gps_position.altitude);
+        Serial.print("Satellites: ");
+        Serial.println((int)gps_position.satelites);
+    }
+}
+
+}  // namespace obc

--- a/src/gps.cpp
+++ b/src/gps.cpp
@@ -1,0 +1,70 @@
+#include "gps.hpp"
+#include <Arduino.h>
+
+namespace obc{
+
+    void init(Gps& gps)
+    {
+        Serial.begin(115200);
+        gps.begin(9600);
+        gps.sendCommand(PMTK_SET_NMEA_OUTPUT_RMCGGA);
+        gps.sendCommand(PMTK_SET_NMEA_UPDATE_1HZ); // 1 Hz update rate
+        gps.sendCommand(PGCMD_ANTENNA);
+        delay(1000);
+        GPSSerial.println(PMTK_Q_RELEASE);
+    }
+    GpsMeasurments measure_gps(Gps& gps)
+    {
+        char c = gps.read();
+            if (GPSECHO)
+              if (c) Serial.print(c);
+          if (gps.newNMEAreceived()) {
+            if (!gps.parse(gps.lastNMEA()))
+            return {{},{},{},Error::Busy};
+          }
+        return {{gps.hour,gps.minute,gps.seconds,gps.milliseconds},
+                {gps.year,gps.month,gps.day},
+                {gps.fix,gps.fixquality,gps.longitudeDegrees,gps.lon,gps.latitudeDegrees,gps.lat,gps.altitude,gps.speed,gps.satellites},
+                Error::Ok};
+
+    }
+    void print(const GpsTime& gps_time)
+    {
+        Serial.print("\nTime: ");
+        if (gps_time.hour < 10) { Serial.print('0'); }
+        Serial.print(gps_time.hour, DEC); Serial.print(':');
+        if (gps_time.minute < 10) { Serial.print('0'); }
+        Serial.print(gps_time.minute, DEC); Serial.print(':');
+        if (gps_time.seconds < 10) { Serial.print('0'); }
+        Serial.print(gps_time.seconds, DEC); Serial.print('.');
+        if (gps_time.milliseconds < 10) {
+          Serial.print("00");
+        } else if (gps_time.milliseconds > 9 && gps_time.milliseconds < 100) {
+          Serial.print("0");
+        }
+        Serial.println(gps_time.milliseconds);
+    }
+    void print(const GpsDate& gps_date)
+    {
+        Serial.print("Date: ");
+        Serial.print(gps_date.day, DEC); Serial.print('/');
+        Serial.print(gps_date.month, DEC); Serial.print("/20");
+        Serial.println(gps_date.year, DEC);
+      
+    }
+    void print(const GpsPosition& gps_position)
+    {
+        Serial.print("Fix: "); Serial.print((int)gps_position.fix);
+        Serial.print(" quality: "); Serial.println((int)gps_position.fixquality);
+        if (gps_position.fix) {
+          Serial.print("Location: ");
+          Serial.print(gps_position.latitude, 4); Serial.print(gps_position.lat);
+          Serial.print(", ");
+          Serial.print(gps_position.longitude, 4); Serial.println(gps_position.lon);
+          Serial.print("Speed (km/h): "); Serial.println(gps_position.speed/1.85166);
+          Serial.print("Altitude: "); Serial.println(gps_position.altitude);
+          Serial.print("Satellites: "); Serial.println((int)gps_position.satelites);
+        }
+    }
+
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@ constexpr auto baud_rate = 9600L;
 HardwareSerial Serial3(PC11, PC10);
 obc::Accelerometer acclrm;
 obc::Bmp bmp;
-obc::Gps gps(&GPSSerial);
+obc::Gps gps(&Serial3);
 
 uint32_t timer = millis();
 
@@ -24,12 +24,13 @@ void setup()
 
 void loop()
 {
+    constexpr int gps_interval = 2000;
     const auto [acclr, acclr_err] = obc::measure(acclrm);
     const auto [measurements, bmp_err] = obc::measure(bmp);
     const auto [time,date,gpsposition,err] = obc::measure_gps(gps);
     if (acclr_err == obc::Error::Ok) { obc::print(acclr); }
     if (bmp_err == obc::Error::Ok) { obc::print(measurements); }
-    if(err == obc::Error::Ok && timer - millis() > 2000)
+    if(err == obc::Error::Ok && timer - millis() > gps_interval)
     {
         obc::print(time);
         obc::print(date);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,7 +12,6 @@ obc::Gps gps(&Serial3);
 
 uint32_t timer = millis();
 
-
 void setup()
 {
     Serial.begin(baud_rate);
@@ -27,11 +26,10 @@ void loop()
     constexpr int gps_interval = 2000;
     const auto [acclr, acclr_err] = obc::measure(acclrm);
     const auto [measurements, bmp_err] = obc::measure(bmp);
-    const auto [time,date,gpsposition,err] = obc::measure_gps(gps);
+    const auto [time, date, gpsposition, err] = obc::measure_gps(gps);
     if (acclr_err == obc::Error::Ok) { obc::print(acclr); }
     if (bmp_err == obc::Error::Ok) { obc::print(measurements); }
-    if(err == obc::Error::Ok && timer - millis() > gps_interval)
-    {
+    if (err == obc::Error::Ok && timer - millis() > gps_interval) {
         obc::print(time);
         obc::print(date);
         obc::print(gpsposition);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,10 +2,16 @@
 
 #include "acceleration.hpp"
 #include "barometer.hpp"
+#include "gps.hpp"
 
 constexpr auto baud_rate = 9600L;
+HardwareSerial Serial3(PC11, PC10);
 obc::Accelerometer acclrm;
 obc::Bmp bmp;
+obc::Gps gps(&GPSSerial);
+
+uint32_t timer = millis();
+
 
 void setup()
 {
@@ -13,12 +19,21 @@ void setup()
     Serial.println("setup");
     obc::init(acclrm);
     obc::init(bmp);
+    obc::init(gps);
 }
 
 void loop()
 {
     const auto [acclr, acclr_err] = obc::measure(acclrm);
     const auto [measurements, bmp_err] = obc::measure(bmp);
+    const auto [time,date,gpsposition,err] = obc::measure_gps(gps);
     if (acclr_err == obc::Error::Ok) { obc::print(acclr); }
     if (bmp_err == obc::Error::Ok) { obc::print(measurements); }
+    if(err == obc::Error::Ok && timer - millis() > 2000)
+    {
+        obc::print(time);
+        obc::print(date);
+        obc::print(gpsposition);
+        timer = millis();
+    }
 }


### PR DESCRIPTION
Clang tidy wywalił 7 ostrzeżeń o 'magic number'. Oprócz tego wszystko przeszło